### PR TITLE
fix: fixing python version

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.11
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
Since Python 3.13 is not yet widely supported by many libraries, including Django, so I downgraded python version to 3.11